### PR TITLE
Fix(RenderNLFPoses): Use normalized coordinates for alignment

### DIFF
--- a/NLFPoseExtract/align3d.py
+++ b/NLFPoseExtract/align3d.py
@@ -4,23 +4,18 @@ from scipy.optimize import minimize
 
 def solve_new_camera_params_central(three_d_points, focal_length, imshape, new_2d_points):
     """
-    Solve for new camera parameters by minimizing the error between the original 2D projection points and the new 2D projection points.
-
-    Args:
-        three_d_points (torch.Tensor): N*3 3D points
-        focal_length (float): Focal length of the original camera
-        imshape (tuple): Image size, e.g., [512, 896]
-        original_2d_points (torch.Tensor): N*2 original 2D projection points
-        new_2d_points (torch.Tensor): N*2 new 2D projection points
-
-    Returns:
-        m, n, p, q: Parameters in the new camera intrinsic matrix
+    Solve for new camera parameters by minimizing the error between the projected 3D points and the target 2D points.
+    This version operates in NORMALIZED coordinate space for resolution independence.
     """
 
-
-    # Objective function: minimize the error between the original projection points and the new projection points
+    # Objective function: minimize the error between the projected points and the target 2d points.
     def objective(params):
-        m, s, p, q = params
+        m, s, p_norm, q_norm = params
+        
+        # Convert normalized offsets (p_norm, q_norm) to pixel offsets for matrix construction
+        p = p_norm * imshape[1]
+        q = q_norm * imshape[0]
+
         # Construct the new camera intrinsic matrix
         K_new = np.array([
             [focal_length * m , 0, imshape[1] / 2 + p],
@@ -28,96 +23,97 @@ def solve_new_camera_params_central(three_d_points, focal_length, imshape, new_2
             [0, 0, 1]
         ])
 
-        # Compute the new 2D projection points
-        new_projections = []
+        # Compute the new 2D projection points in pixel space
+        new_projections_px = []
         for point in three_d_points:
             X, Y, Z = point
+            if Z == 0: Z = 1e-6 # Avoid division by zero
             u = (K_new[0, 0] * X / Z) + K_new[0, 2]
             v = (K_new[1, 1] * Y / Z) + K_new[1, 2]
-            new_projections.append([u, v])
-        new_projections = np.array(new_projections)
+            new_projections_px.append([u, v])
+        new_projections_px = np.array(new_projections_px)
 
-        # Calculate the error between the original 2D projection points and the new projection points
-        # Special handling for the 0th projection point
-        error0 = np.sum((new_2d_points[:1] - new_projections[:1]) ** 2)
-        error = np.sum((new_2d_points[1:] - new_projections[1:]) ** 2)
+        # Normalize the calculated projections before comparison
+        new_projections_norm = new_projections_px.copy()
+        new_projections_norm[:, 0] /= imshape[1]
+        new_projections_norm[:, 1] /= imshape[0]
+
+        # Calculate the error in normalized space as new_2d_points is already normalized.
+        error0 = np.sum((new_2d_points[:1] - new_projections_norm[:1]) ** 2)
+        error = np.sum((new_2d_points[1:] - new_projections_norm[1:]) ** 2)
         return error0 * 8 + error
 
-    # Initialize parameters m, beta, p, q
-    initial_params = [1.0, 1.0, 0.0, 0.0]  # Initial values
+    # Initial parameters [scale, y_scale, norm_offset_x, norm_offset_y]
+    initial_params = [1.0, 1.0, 0.0, 0.0]
 
-    # Use least squares to solve for p, q
-    result = minimize(objective, initial_params, bounds=[(0.7, 1.4), (0.8, 1.15), (-imshape[1], imshape[1]), (-imshape[0], imshape[0])])
+    # Use optimizer. Bounds for normalized offsets are [-1, 1].
+    result = minimize(objective, initial_params, bounds=[(0.7, 1.4), (0.8, 1.15), (-1.0, 1.0), (-1.0, 1.0)])
 
-    # Output the solution result
-    m, s, p, q = result.x
-    print(f"debug: solved camera params m={m}, s={s}, p={p}, q={q}")
+    m, s, p_norm, q_norm = result.x
+    print(f"debug: solved camera params m={m}, s={s}, p_norm={p_norm}, q_norm={q_norm}")
 
+    # Re-calculate final pixel offsets for the output matrix
+    p = p_norm * imshape[1]
+    q = q_norm * imshape[0]
+    
     K_final = np.array([
         [focal_length * m, 0, imshape[1] / 2 + p],
         [0, focal_length * m * s, imshape[0] / 2 + q],
         [0, 0, 1]
     ])
-
 
     return K_final, m, s
 
 
 def solve_new_camera_params_down(three_d_points, focal_length, imshape, new_2d_points):
     """
-    Solve for new camera parameters by minimizing the error between the original 2D projection points and the new 2D projection points.
-
-    Args:
-        three_d_points (torch.Tensor): N*3 3D points
-        focal_length (float): Focal length of the original camera
-        imshape (tuple): Image size, e.g., [512, 896]
-        original_2d_points (torch.Tensor): N*2 original 2D projection points
-        new_2d_points (torch.Tensor): N*2 new 2D projection points
-
-    Returns:
-        m, n, p, q: Parameters in the new camera intrinsic matrix
+    Solve for new camera parameters, prioritizing alignment of the lower body.
+    This version operates in NORMALIZED coordinate space for resolution independence.
     """
 
-    # Objective function: minimize the error between the original projection points and the new projection points
     def objective(params):
-        m, s, p, q = params
-        # Construct the new camera intrinsic matrix
+        m, s, p_norm, q_norm = params
+
+        p = p_norm * imshape[1]
+        q = q_norm * imshape[0]
+
         K_new = np.array([
             [focal_length * m , 0, imshape[1] / 2 + p],
             [0, focal_length * m * s, imshape[0] / 2 + q],
             [0, 0, 1]
         ])
 
-        # Compute the new 2D projection points
-        new_projections = []
+        new_projections_px = []
         for point in three_d_points:
             X, Y, Z = point
+            if Z == 0: Z = 1e-6 # Avoid division by zero
             u = (K_new[0, 0] * X / Z) + K_new[0, 2]
             v = (K_new[1, 1] * Y / Z) + K_new[1, 2]
-            new_projections.append([u, v])
-        new_projections = np.array(new_projections)
+            new_projections_px.append([u, v])
+        new_projections_px = np.array(new_projections_px)
 
-        # Calculate the error between the original 2D projection points and the new projection points
-        # Special handling for the 0th projection point
-        error0 = np.sum((new_2d_points[:1] - new_projections[:1]) ** 2)
-        error = np.sum((new_2d_points[1:] - new_projections[1:]) ** 2)
+        new_projections_norm = new_projections_px.copy()
+        new_projections_norm[:, 0] /= imshape[1]
+        new_projections_norm[:, 1] /= imshape[0]
+        
+        error0 = np.sum((new_2d_points[:1] - new_projections_norm[:1]) ** 2)
+        error = np.sum((new_2d_points[1:] - new_projections_norm[1:]) ** 2)
         return error0 + error * 4
 
-    # Initialize parameters m, beta, p, q
-    initial_params = [1.0, 1.0, 0.0, 0.0]  # Initial values
+    initial_params = [1.0, 1.0, 0.0, 0.0]
 
-    # Use least squares to solve for p, q
-    result = minimize(objective, initial_params, bounds=[(0.7, 1.4), (0.8, 1.15), (-imshape[1], imshape[1]), (-imshape[0], imshape[0])])
+    result = minimize(objective, initial_params, bounds=[(0.7, 1.4), (0.8, 1.15), (-1.0, 1.0), (-1.0, 1.0)])
 
-    # Output the solution result
-    m, s, p, q = result.x
-    print(f"debug: solved camera params m={m}, s={s}, p={p}, q={q}")
+    m, s, p_norm, q_norm = result.x
+    print(f"debug: solved camera params m={m}, s={s}, p_norm={p_norm}, q_norm={q_norm}")
+
+    p = p_norm * imshape[1]
+    q = q_norm * imshape[0]
 
     K_final = np.array([
         [focal_length * m, 0, imshape[1] / 2 + p],
         [0, focal_length * m * s, imshape[0] / 2 + q],
         [0, 0, 1]
     ])
-
 
     return K_final, m, s

--- a/nodes.py
+++ b/nodes.py
@@ -313,8 +313,6 @@ class RenderNLFPoses:
 
             pose_3d_coco_first_driving_frame = process_data_to_COCO_format(pose_3d_first_driving_frame)
             poses_2d_ref = ref_dw_pose_input[0]['bodies']['candidate'][0][:14]
-            poses_2d_ref[:, 0] = poses_2d_ref[:, 0] * width
-            poses_2d_ref[:, 1] = poses_2d_ref[:, 1] * height
 
             poses_2d_subset = ref_dw_pose_input[0]['bodies']['subset'][0][:14]
             pose_3d_coco_first_driving_frame = pose_3d_coco_first_driving_frame[:14]

--- a/nodes.py
+++ b/nodes.py
@@ -137,9 +137,6 @@ def scale_faces(poses, pose_2d_ref):
         scaled_candidate = (candidate_np - body_center) * scale_n + body_center
         poses[i]['bodies']['candidate'][0] = scaled_candidate
 
-    # In-place modification
-    pose['faces'][0] = scaled_face
-
     return scale_n
 
 class PoseDetectionVitPoseToDWPose:

--- a/pose_draw/draw_utils.py
+++ b/pose_draw/draw_utils.py
@@ -152,14 +152,14 @@ def draw_bodypose_with_feet(canvas, candidate, subset):
             index = subset[n][np.array(limbSeq[i]) - 1]
             if -1 in index:
                 continue
-            Y = candidate[index.astype(int), 0] * float(W)
-            X = candidate[index.astype(int), 1] * float(H)
-            mX = np.mean(X)
-            mY = np.mean(Y)
-            length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
-            angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+            x = candidate[index.astype(int), 0] * float(W)
+            y = candidate[index.astype(int), 1] * float(H)
+            mX = np.mean(x)
+            mY = np.mean(y)
+            length = ((x[0] - x[1]) ** 2 + (y[0] - y[1]) ** 2) ** 0.5
+            angle = math.degrees(math.atan2(y[0] - y[1], x[0] - x[1]))
             polygon = cv2.ellipse2Poly(
-                (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+                (int(mX), int(mY)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
             )
             cv2.fillConvexPoly(canvas, polygon, colors[i])
 
@@ -168,14 +168,14 @@ def draw_bodypose_with_feet(canvas, candidate, subset):
             index = subset[n][np.array(foot_limbSeq[i]) - 1]
             if -1 in index:
                 continue
-            Y = candidate[index.astype(int), 0] * float(W)
-            X = candidate[index.astype(int), 1] * float(H)
-            mX = np.mean(X)
-            mY = np.mean(Y)
-            length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
-            angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+            x = candidate[index.astype(int), 0] * float(W)
+            y = candidate[index.astype(int), 1] * float(H)
+            mX = np.mean(x)
+            mY = np.mean(y)
+            length = ((x[0] - x[1]) ** 2 + (y[0] - y[1]) ** 2) ** 0.5
+            angle = math.degrees(math.atan2(y[0] - y[1], x[0] - x[1]))
             polygon = cv2.ellipse2Poly(
-                (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+                (int(mX), int(mY)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
             )
             cv2.fillConvexPoly(canvas, polygon, colors_feet[i])
 
@@ -264,21 +264,21 @@ def draw_bodypose_augmentation(canvas, candidate, subset, drop_aug=True, shift_a
             index = subset[n][np.array(limbSeq[i]) - 1]
             if -1 in index:
                 continue
-            Y = candidate[index.astype(int), 0] * float(W)
-            X = candidate[index.astype(int), 1] * float(H)
+            x = candidate[index.astype(int), 0] * float(W)
+            y = candidate[index.astype(int), 1] * float(H)
 
             if i in drop_indices:
                 continue
 
-            mX = np.mean(X)   # Calculate the midpoint between two joints
-            mY = np.mean(Y)
-            length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+            mX = np.mean(x)
+            mY = np.mean(y)
+            length = ((x[0] - x[1]) ** 2 + (y[0] - y[1]) ** 2) ** 0.5
             if i in shift_indices:
                 mX = mX + random.uniform(-length/4, length/4)
                 mY = mY + random.uniform(-length/4, length/4)
-            angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+            angle = math.degrees(math.atan2(y[0] - y[1], x[0] - x[1]))
             polygon = cv2.ellipse2Poly(
-                (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+                (int(mX), int(mY)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
             )
             cv2.fillConvexPoly(canvas, polygon, colors[i])
 
@@ -354,14 +354,14 @@ def draw_bodypose(canvas, candidate, subset):
             index = subset[n][np.array(limbSeq[i]) - 1]
             if -1 in index:
                 continue
-            Y = candidate[index.astype(int), 0] * float(W)
-            X = candidate[index.astype(int), 1] * float(H)
-            mX = np.mean(X)
-            mY = np.mean(Y)
-            length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
-            angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+            x = candidate[index.astype(int), 0] * float(W)
+            y = candidate[index.astype(int), 1] * float(H)
+            mX = np.mean(x)
+            mY = np.mean(y)
+            length = ((x[0] - x[1]) ** 2 + (y[0] - y[1]) ** 2) ** 0.5
+            angle = math.degrees(math.atan2(y[0] - y[1], x[0] - x[1]))
             polygon = cv2.ellipse2Poly(
-                (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+                (int(mX), int(mY)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
             )
             cv2.fillConvexPoly(canvas, polygon, colors[i])
 


### PR DESCRIPTION
Description: This PR resolves the coordinate mapping bug where the skeleton would offset to the bottom-right when the driving video and reference image had different resolutions (even with the same aspect ratio).

Key Changes:

Fixes #22 

Implemented normalized coordinate mapping (0.0 to 1.0 range) for alignment_offset calculation to ensure consistency across different resolutions.

Improved pose retargeting logic for better character proportion matching (especially for chibi/shorter characters).

Fixed the cumulative pixel-based offset error in the RenderNLFPoses node.

Verification: Confirmed that 576x1024 video poses now align perfectly with 720x1280 reference images without any drifting.